### PR TITLE
Use PyArrow instead of Pandas to read and write CSV files

### DIFF
--- a/dataiter/test/test_data_frame.py
+++ b/dataiter/test/test_data_frame.py
@@ -448,6 +448,70 @@ class TestDataFrame:
         assert data.make.is_object()
         assert data.model.is_object()
 
+    def test_read_csv_missing_blank(self):
+        text = """
+int,float,string,bool,date
+,2.5,"test",TRUE,2025-01-01
+1,,"test",TRUE,2025-01-01
+1,2.5,"",TRUE,2025-01-01
+1,2.5,"test",,2025-01-01
+1,2.5,"test",TRUE,
+""".strip()
+        handle, path = tempfile.mkstemp(".csv")
+        Path(path).write_text(text, "utf-8")
+        data = DataFrame.read_csv(path)
+        for i, column in enumerate(data.columns):
+            assert column.is_na().sum() == 1
+            assert column.is_na()[i]
+
+    def test_read_csv_missing_excel(self):
+        text = """
+int,float,string,bool,date
+#N/A,2.5,"test",TRUE,2025-01-01
+1,#N/A,"test",TRUE,2025-01-01
+1,2.5,"",TRUE,2025-01-01
+1,2.5,"test",#N/A,2025-01-01
+1,2.5,"test",TRUE,#N/A
+""".strip()
+        handle, path = tempfile.mkstemp(".csv")
+        Path(path).write_text(text, "utf-8")
+        data = DataFrame.read_csv(path)
+        for i, column in enumerate(data.columns):
+            assert column.is_na().sum() == 1
+            assert column.is_na()[i]
+
+    def test_read_csv_missing_na(self):
+        text = """
+int,float,string,bool,date
+NA,2.5,"test",TRUE,2025-01-01
+1,NA,"test",TRUE,2025-01-01
+1,2.5,"",TRUE,2025-01-01
+1,2.5,"test",NA,2025-01-01
+1,2.5,"test",TRUE,NA
+""".strip()
+        handle, path = tempfile.mkstemp(".csv")
+        Path(path).write_text(text, "utf-8")
+        data = DataFrame.read_csv(path)
+        for i, column in enumerate(data.columns):
+            assert column.is_na().sum() == 1
+            assert column.is_na()[i]
+
+    def test_read_csv_missing_null(self):
+        text = """
+int,float,string,bool,date
+NULL,2.5,"test",TRUE,2025-01-01
+1,NULL,"test",TRUE,2025-01-01
+1,2.5,"",TRUE,2025-01-01
+1,2.5,"test",NULL,2025-01-01
+1,2.5,"test",TRUE,NULL
+""".strip()
+        handle, path = tempfile.mkstemp(".csv")
+        Path(path).write_text(text, "utf-8")
+        data = DataFrame.read_csv(path)
+        for i, column in enumerate(data.columns):
+            assert column.is_na().sum() == 1
+            assert column.is_na()[i]
+
     def test_read_json(self):
         path = str(test.get_data_path("downloads.json"))
         data = DataFrame.read_json(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9.0"
 authors = [{ name = "Osmo Salomaa", email = "otsaloma@iki.fi" }]
-dependencies = ["attd>=0.3", "numpy>=2.0,<3.0", "pandas>=1.0", "wcwidth>=0.1"]
+dependencies = ["attd>=0.3", "numpy>=2.0,<3.0", "pyarrow>=2.0", "wcwidth>=0.1"]
 
 [project.urls]
 Homepage = "https://github.com/otsaloma/dataiter"

--- a/validation/validate-df.sh
+++ b/validation/validate-df.sh
@@ -4,11 +4,13 @@ rm -f *.R.csv
 echo "Generating data..."
 python3 generate-df.py
 Rscript generate.R
+# Remove quotes around strings.
+sed -ri 's/"//g' *.csv
 # Remove trailing zero decimals.
 sed -ri "s/\.0*(,|$)/\1/g" *.csv
 # Unify spelling of special values.
-sed -ri "s/True/TRUE/g" *.csv
-sed -ri "s/False/FALSE/g" *.csv
+sed -ri "s/true/TRUE/gi" *.csv
+sed -ri "s/false/FALSE/gi" *.csv
 EXIT_STATUS=0
 for NUM in $(ls *.df.csv | cut -d. -f1); do
     printf "%-23s" "Checking $NUM... "

--- a/validation/validate-ld.sh
+++ b/validation/validate-ld.sh
@@ -4,11 +4,13 @@ rm -f *.R.csv
 echo "Generating data..."
 python3 generate-ld.py
 Rscript generate.R
+# Remove quotes around strings.
+sed -ri 's/"//g' *.csv
 # Remove trailing zero decimals.
 sed -ri "s/\.0*(,|$)/\1/g" *.csv
 # Unify spelling of special values.
-sed -ri "s/True/TRUE/g" *.csv
-sed -ri "s/False/FALSE/g" *.csv
+sed -ri "s/true/TRUE/gi" *.csv
+sed -ri "s/false/FALSE/gi" *.csv
 EXIT_STATUS=0
 for NUM in $(ls *.ld.csv | cut -d. -f1); do
     printf "%-23s" "Checking $NUM... "


### PR DESCRIPTION
Since CSV file parsing is such an ill-defined problem and CSV files such diverse, this is likely to introduce some changes or regressions in weird cases, but didn't see anything in testing.

Also updated `from_pandas`to match to the rewritten `from_arrow`. Using Pandas might be a bit more robust now for some less common data types.

Closes #22 